### PR TITLE
fix: ビルド後に実行権限を自動付与

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kindle-title-exporter",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Export your Kindle library to CSV or JSON",
   "main": "dist/index.js",
   "files": [
@@ -10,6 +10,7 @@
   ],
   "scripts": {
     "build": "tsc",
+    "postbuild": "chmod +x dist/index.js",
     "start": "node dist/index.js",
     "dev": "ts-node src/index.ts",
     "test": "vitest",


### PR DESCRIPTION
## 問題

v1.0.0公開後、`npx kindle-title-exporter`実行時に以下のエラーが発生：
```
Permission denied
```

原因: TypeScriptコンパイル時に`dist/index.js`に実行権限が付与されない

## 解決策

`postbuild`スクリプトを追加し、ビルド後に自動的に実行権限を付与：
```json
"postbuild": "chmod +x dist/index.js"
```

## 変更内容

- postbuildスクリプトを追加
- バージョンを1.0.1に更新
- 59テスト全通過確認済み
- npm publish --dry-run確認済み

## 確認済み項目

- ✅ ビルド後に実行権限が付与される（-rwxr-xr-x）
- ✅ `./dist/index.js --help`が正常に動作
- ✅ 全テスト通過（59テスト）
- ✅ dry-runでパッケージ内容確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)